### PR TITLE
feat: Add kube-hunter chart

### DIFF
--- a/charts/kube-hunter/.helmignore
+++ b/charts/kube-hunter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kube-hunter/Chart.yaml
+++ b/charts/kube-hunter/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: kube-hunter
+description: Deploys a kube-hunter job
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.3.1

--- a/charts/kube-hunter/templates/NOTES.txt
+++ b/charts/kube-hunter/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Find the pod name by running:
+   kubectl describe job  {{ .Chart.Name }}
+
+2. View the hunt results:
+   kubectl logs <podname>

--- a/charts/kube-hunter/templates/_helpers.tpl
+++ b/charts/kube-hunter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-hunter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-hunter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-hunter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-hunter.labels" -}}
+helm.sh/chart: {{ include "kube-hunter.chart" . }}
+{{ include "kube-hunter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kube-hunter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kube-hunter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-hunter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kube-hunter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kube-hunter/templates/job.yaml
+++ b/charts/kube-hunter/templates/job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kube-hunter.fullname" . }}
+  labels:
+    {{- include "kube-hunter.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+    {{- with .Values.jobAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "kube-hunter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["kube-hunter"]
+        args:
+          {{- toYaml .Values.image.args | nindent 12}}
+      restartPolicy: Never
+  backoffLimit: 4

--- a/charts/kube-hunter/values.yaml
+++ b/charts/kube-hunter/values.yaml
@@ -1,0 +1,17 @@
+# Default values for kube-hunter.
+image:
+  repository: aquasec/kube-hunter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  args: ["--pod"]
+
+jobAnnotations: {}
+imagePullSecrets: []
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000


### PR DESCRIPTION
Without this patch, kube-hunter is only theoretical.
Now we can deploy kube-hunter using our own helm chart.

Fixes: #16