### PR TITLE
ci: Add auto-squash merge

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -1,0 +1,44 @@
+name: Autosquash
+on:
+  check_run:
+    types:
+      # Check runs completing successfully can unblock the
+      # corresponding pull requests and make them mergeable.
+      - completed
+  pull_request:
+    types:
+      # A closed pull request makes the checks on the other
+      # pull request on the same base outdated.
+      - closed
+      # Adding the autosquash label to a pull request can
+      # trigger an update or a merge.
+      - labeled
+  pull_request_review:
+    types:
+      # Review approvals can unblock the pull request and
+      # make it mergeable.
+      - submitted
+  # Success statuses can unblock the corresponding
+  # pull requests and make them mergeable.
+  status: {}
+
+jobs:
+  autosquash:
+    name: Autosquash
+    runs-on: ubuntu-18.04
+    steps:
+      # We can't use the built-in secrets.GITHUB_TOKEN yet because of this limitation:
+      # https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
+      # In the meantime, use a token granting write access on the repo:
+      # - a GitHub App token
+      #   See https://github.com/marketplace/actions/github-app-token.
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.AUTOSQUASH_APP_ID }}
+          private_key: ${{ secrets.AUTOSQUASH_APP_PEM }}
+
+      - uses: tibdex/autosquash@v2
+        with:
+          github_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Without this patch, PRs are not ensured to be properly formatted,
as ther person merging will need to have this little text box to
format the message before merge.

This is not a big problem, but I think it's better to have
a consistent message, and PR message text is easy to review.

This automatically ensures the ready to merge PRs go
through a bot taking the PR message and merging all its
commits into the target branch, as a single commit, by
squashing them together.