### PR TITLE
docs: Add semantic commit explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ The docs source is in docs/source/ (obviously?!).
 
 If you are not familiar with restructured text, please have a looksie in here:
 https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+
+## Step 4: Prepare your commit
+
+This repo uses semantic commits. If you write your commit well, there is
+_nothing_ to be done for releasing.
+
+Here is a link to the information you need to put in your commit message.
+
+https://www.conventionalcommits.org/en/v1.0.0/#summary
+
+Don't forget that commits should be explaining the context of the WHY
+you do something.


### PR DESCRIPTION
Without this, people might not know what to send as commit message.

This is a problem as this might be causing friction: Some things
won't get auto merged, and will become stale.

This fixes it by clarifying expectations for contributors and
reviewers.

-----
[View rendered README.md](https://github.com/evrardjp/super-waffle/blob/docs/semantic-commits/README.md)