### PR TITLE
fix: Loosen the rules for semantic checks

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,4 @@
+# Always validates PRs texts, as this will be the base for auto-squash
+titleOnly: true
+# Never validates commits. We trust the reviewers
+commitsOnly: false


### PR DESCRIPTION
We just need the PR to be correct semantically, as it is what
will be merged. The commits only matter for reviewing, and for
context when checking the history.